### PR TITLE
fixed bootstarp 4 logo & python logo

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -65,3 +65,5 @@
 [@codepol](https://github.com/codepol)
 
 [@sandy8169](https://github.com/sandy8169)
+
+[@Itailevi420](https://github.com/Itailevi420)

--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
                         <div class="card-body">
                             <h5 class="card-title">Bootstrap 4</h5>
                             <p class="card-text">
-                                <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/ea/Boostrap_logo.svg/440px-Boostrap_logo.svg.png" alt="Bootstrap 4">
+                                <img src="https://miro.medium.com/max/1024/1*9HanDsRU11ZMsgDGJwN96w.png" alt="Bootstrap 4">
                             </p>
                         </div>
                     </div>
@@ -147,7 +147,7 @@
                         <div class="card-body">
                             <h5 class="card-title">Python</h5>
                             <p class="card-text">
-                                <img src="https://www.python.org/static/community_logos/python-logo-master-v3-TM-flattened.png" alt="Python">
+                                <img src="https://cdn.freebiesupply.com/logos/large/2x/python-5-logo-png-transparent.png" alt="Python">
                             </p>
                         </div>
                     </div>


### PR DESCRIPTION
Hi, the Bootstarp logo was broken.
Python logo was very small hope it's a good fix.