### PR TITLE
Capitalizing ZtM to ZTM

### DIFF
--- a/about.html
+++ b/about.html
@@ -69,7 +69,7 @@
     
     <div class="animated bounce">
       <div class="container-fluid about-container">
-        <h1 class="animated bounce">The Complete Web Developer in 2020: ZtM</h1>
+        <h1 class="animated bounce">The Complete Web Developer in 2020: ZTM</h1>
         <h2 class="animated bounce">Course Content</h2>
 
         <ul class="list-group list-group-flush">


### PR DESCRIPTION
I Capitalized ZtM to ZTM as it's looking a bit odd to just see the t in small letter.

As you already know Andrei always uses capital 'T' in all of his course titles, let's capitalize!

Regards,
@AswinBarath 