### PR TITLE
fix register page side scroll

### DIFF
--- a/resources/style/register-page.css
+++ b/resources/style/register-page.css
@@ -1,3 +1,8 @@
+body, html {
+    max-width: 100%;
+    overflow-x: hidden;
+}
+
 .navbar-collapse {
     color: #000 !important;
 }


### PR DESCRIPTION
The page for the registration has an animation that moves horizontally across the screen. This causes the page to develop an unnecessary and increasingly long side scroll bar. Since the side scroll bar is not going to be used on that page (even when zoomed-in), I disabled the side scroll for the page.