### PR TITLE
Fixed git logo at the botoom which was not aligned properly

### DIFF
--- a/contributersProfile.html
+++ b/contributersProfile.html
@@ -569,7 +569,7 @@
         </div> -->
             </div>
             <div id="credits">
-              <div class="center git">
+              <div class="center git buttons">
                 <a href="https://github.com/zero-to-mastery/HTML-project">
                   <img id="laptop" src="resources/images/git.svg" title="Repository link" alt="Git Icon" border="0">
                 </a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
I noticed that at contributors page, the git logo at the bottom of the page was not aligned properly. I have fixed it to center the logo with rest of the elements.